### PR TITLE
Moved express.static to be set before routes setup

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -29,13 +29,13 @@ function ngApp(req, res) {
   });
 }
 
+// Serve static files
+app.use(express.static(root));
+
 // Routes
 app.use('/', ngApp);
 app.use('/about', ngApp);
 app.use('/home', ngApp);
-
-// Serve static files
-app.use(express.static(root));
 
 // Server
 app.listen(3000, () => {


### PR DESCRIPTION
vendor, polyfills and bundle js could not be loaded on the page because the route of the app were used before the setup of static route. Its fixed by setting the static route before the others.