### PR TITLE
chore(package): peer deps fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "reflect-metadata": "0.1.2",
     "rxjs": "5.0.0-beta.0",
     "xhr2": "^0.1.3",
-    "zone.js": "~0.5.11"
+    "zone.js": "0.5.10"
   },
   "devDependencies": {
     "gulp": "^3.9.0",


### PR DESCRIPTION
Fixing the `zone.js` dep to be locked to `0.5.10` to fix `npm install` errors.