### PR TITLE
chore(prerender): update package versions for prerender build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ npm-debug.log
 
 /dist/
 
+.idea

--- a/Gruntfile.ts
+++ b/Gruntfile.ts
@@ -10,8 +10,6 @@ import {REQUEST_URL, NODE_LOCATION_PROVIDERS} from 'angular2-universal-preview';
 import {provide, enableProdMode} from 'angular2/core';
 import {APP_BASE_HREF, ROUTER_PROVIDERS} from 'angular2/router';
 import {App} from './src/app/app';
-import {Title, ServerOnlyApp} from './src/server-only-app/server-only-app';
-
 enableProdMode();
 
 module.exports = function(grunt) {
@@ -35,7 +33,7 @@ module.exports = function(grunt) {
     'angular2-prerender': {
       default_options: {
         options: {
-          directives: [App, Title, ServerOnlyApp],
+          App,
           providers: [
             provide(APP_BASE_HREF, { useValue: '/' }),
             provide(REQUEST_URL, { useValue: '/' }),

--- a/Gruntfile.ts
+++ b/Gruntfile.ts
@@ -10,6 +10,8 @@ import {REQUEST_URL, NODE_LOCATION_PROVIDERS} from 'angular2-universal-preview';
 import {provide, enableProdMode} from 'angular2/core';
 import {APP_BASE_HREF, ROUTER_PROVIDERS} from 'angular2/router';
 import {App} from './src/app/app';
+import {Title, ServerOnlyApp} from './src/server-only-app/server-only-app';
+
 enableProdMode();
 
 module.exports = function(grunt) {
@@ -33,14 +35,14 @@ module.exports = function(grunt) {
     'angular2-prerender': {
       default_options: {
         options: {
-          App,
+          directives: [App, Title, ServerOnlyApp],
           providers: [
             provide(APP_BASE_HREF, { useValue: '/' }),
             provide(REQUEST_URL, { useValue: '/' }),
             ROUTER_PROVIDERS,
             NODE_LOCATION_PROVIDERS,
           ],
-          preboot: true
+          preboot: false
         },
         files: {
           'tmp/default_options': [

--- a/Gruntfile.ts
+++ b/Gruntfile.ts
@@ -40,7 +40,7 @@ module.exports = function(grunt) {
             ROUTER_PROVIDERS,
             NODE_LOCATION_PROVIDERS,
           ],
-          preboot: false
+          preboot: true
         },
         files: {
           'tmp/default_options': [

--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -7,7 +7,6 @@ import {APP_BASE_HREF, ROUTER_PROVIDERS} from 'angular2/router';
 var ngPreRender = require('angular2-gulp-prerender');
 
 import {App} from './src/app/app';
-import {Title, ServerOnlyApp} from './src/server-only-app/server-only-app';
 
 enableProdMode();
 
@@ -15,7 +14,7 @@ gulp.task('prerender', () => {
 
   return gulp.src('./src/index.html')
     .pipe(ngPreRender({
-      directives: [App, Title, ServerOnlyApp],
+      App,
       providers: [
         provide(APP_BASE_HREF, {useValue: '/'}),
         provide(REQUEST_URL, {useValue: '/'}),

--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -1,4 +1,5 @@
 import gulp = require('gulp');
+import 'angular2-universal-preview/polyfills';
 import {REQUEST_URL, NODE_LOCATION_PROVIDERS} from 'angular2-universal-preview';
 import {provide, enableProdMode} from 'angular2/core';
 import {APP_BASE_HREF, ROUTER_PROVIDERS} from 'angular2/router';
@@ -6,6 +7,7 @@ import {APP_BASE_HREF, ROUTER_PROVIDERS} from 'angular2/router';
 var ngPreRender = require('angular2-gulp-prerender');
 
 import {App} from './src/app/app';
+import {Title, ServerOnlyApp} from './src/server-only-app/server-only-app';
 
 enableProdMode();
 
@@ -13,14 +15,14 @@ gulp.task('prerender', () => {
 
   return gulp.src('./src/index.html')
     .pipe(ngPreRender({
-      App,
+      directives: [App, Title, ServerOnlyApp],
       providers: [
         provide(APP_BASE_HREF, {useValue: '/'}),
         provide(REQUEST_URL, {useValue: '/'}),
         ROUTER_PROVIDERS,
         NODE_LOCATION_PROVIDERS,
       ],
-      preboot: true
+      preboot: false
     }))
     .pipe(gulp.dest('dist'));
 });

--- a/gulpfile.ts
+++ b/gulpfile.ts
@@ -21,7 +21,7 @@ gulp.task('prerender', () => {
         ROUTER_PROVIDERS,
         NODE_LOCATION_PROVIDERS,
       ],
-      preboot: false
+      preboot: true
     }))
     .pipe(gulp.dest('dist'));
 });

--- a/package.json
+++ b/package.json
@@ -26,10 +26,10 @@
     "Jeff Cross <crossj@google.com>"
   ],
   "dependencies": {
-    "angular2": "2.0.0-beta.6",
-    "angular2-grunt-prerender": "^0.2.1",
-    "angular2-gulp-prerender": "^0.2.1",
-    "angular2-universal-preview": "~0.55.2",
+    "angular2": "2.0.0-beta.8",
+    "angular2-grunt-prerender": "^0.3.0",
+    "angular2-gulp-prerender": "^0.3.0",
+    "angular2-universal-preview": "~0.70.2",
     "css": "2.2.1",
     "es6-shim": "^0.33.3",
     "express": "^4.13.3",
@@ -37,9 +37,9 @@
     "parse5": "^1.5.0",
     "preboot": "~1.1.0",
     "reflect-metadata": "0.1.2",
-    "rxjs": "5.0.0-beta.0",
+    "rxjs": "5.0.0-beta.2",
     "xhr2": "^0.1.3",
-    "zone.js": "0.5.14"
+    "zone.js": "0.5.15"
   },
   "devDependencies": {
     "grunt": "^0.4.5",
@@ -51,8 +51,9 @@
     "ts-loader": "^0.8.0",
     "ts-node": "^0.5.5",
     "typescript": "^1.7.5",
-    "typings": "^0.6.2",
+    "typings": "^0.6.8",
     "webpack": "^1.12.10",
-    "webpack-dev-server": "^1.14.0"
+    "webpack-dev-server": "^1.14.0",
+    "webpack-merge": "^0.7.1"
   }
 }

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -12,14 +12,7 @@ export class XLarge {
   }
 }
 
-@Component({
-  selector: 'contact',
-  template: `
-  Contact
-  `
-})
-export class Contact {
-}
+
 
 @Component({
   selector: 'home',
@@ -69,9 +62,10 @@ export class About {
   `
 })
 @RouteConfig([
-  { path: '/', component: Home, name: 'Home' },
-  { path: '/contact', component: Contact, name: 'Contact' },
-  { path: '/about', component: About, name: 'About' }
+  { path: '/', component: Home, name: 'Home', useAsDefault: true },
+  { path: '/home', component: Home, name: 'Home' },
+  { path: '/about', component: About, name: 'About' },
+  { path: '/**', redirectTo: ['Home'] }
 ])
 export class App {
   name: string = 'Angular 2';

--- a/src/client.ts
+++ b/src/client.ts
@@ -1,17 +1,12 @@
-import 'es6-shim';
-import 'angular2/bundles/angular2-polyfills';
+import 'angular2-universal-preview/polyfills';
+import {prebootComplete} from 'angular2-universal-preview';
 
 import {bootstrap} from 'angular2/platform/browser';
-import {prebootComplete} from 'angular2-universal-preview';
-import {provide, enableProdMode} from 'angular2/core';
-import {ROUTER_PROVIDERS, LocationStrategy, HashLocationStrategy} from 'angular2/router';
-
-enableProdMode();
+import {ROUTER_PROVIDERS} from 'angular2/router';
 
 import {App} from './app/app';
 
 bootstrap(App, [
-  ...ROUTER_PROVIDERS,
-  provide(LocationStrategy, { useClass: HashLocationStrategy })
+  ...ROUTER_PROVIDERS
 ])
 .then(prebootComplete)

--- a/src/index.html
+++ b/src/index.html
@@ -1,17 +1,24 @@
 <!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>Angular 2 Universal Starter</title>
-  <link rel="icon" href="data:;base64,iVBORw0KGgo=">
-  <base href="/">
-  <script async src="/client/bundle.js"></script>
-</head>
-<body>
+  <head>
+    <meta charset="UTF-8">
+    <meta name="description" content="Angular 2 Universal">
+    <meta name="keywords" content="Angular 2,Universal">
+    <meta name="author" content="PatrickJS">
+    <title>Angular 2 Universal Starter</title>
+    <link rel="icon" href="data:;base64,iVBORw0KGgo=">
+    <base href="/">
+  </head>
+  <body>
 
-  <app>
-    Loading...
-  </app>
+    <app>
+      Loading...
+    </app>
+    <server-only-app>
+      Loading...
+    </server-only-app>
 
-</body>
+    <script async src="/client/bundle.js"></script>
+  </body>
 </html>
+

--- a/src/server-only-app/server-only-app.ts
+++ b/src/server-only-app/server-only-app.ts
@@ -1,0 +1,80 @@
+import {Component} from 'angular2/core';
+
+@Component({
+  selector: 'title',
+  template: `{{ seo }}`
+})
+export class Title {
+  seo = 'Angular 2 Universal Starter - this component replaces the <title> element';
+}
+
+
+
+@Component({
+  selector: 'server-only-app',
+  template: `
+  <footer>{{ seo }}</footer>
+  `
+})
+export class ServerOnlyApp {
+  seo = 'Angular 2 Universal';
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+// WIP: see issue https://github.com/angular/angular/pull/7455 and https://github.com/angular/universal/issues/309
+import {App, Home, About} from '../app/app';
+import {RouteConfig} from 'angular2/router';
+
+@Component({
+  selector: 'html',
+  directives: [
+    Title,
+    App,
+    ServerOnlyApp
+  ],
+  providers: [
+
+  ],
+  template: `
+  <head>
+    <meta charset="UTF-8">
+    <meta name="description" content="Angular 2 Universal">
+    <meta name="keywords" content="Angular 2,Universal">
+    <meta name="author" content="PatrickJS">
+    <title>Angular 2 Universal Starter</title>
+    <link rel="icon" href="data:;base64,iVBORw0KGgo=">
+    <base href="/">
+  </head>
+  <body>
+
+    <app>
+      Loading...
+    </app>
+    <server-only-app>
+      Loading...
+    </server-only-app>
+
+    <script async src="/dist/client/bundle.js"></script>
+  </body>
+  `
+})
+@RouteConfig([
+  { path: '/', component: Home, name: 'Home', useAsDefault: true },
+  { path: '/home', component: Home, name: 'Home' },
+  { path: '/about', component: About, name: 'About' },
+  { path: '/**', redirectTo: ['Home'] }
+])
+export class Html {
+  seo = 'Angular 2 Universal Starter - this component replaces the <title> element';
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,10 +7,12 @@
     "removeComments": true,
     "sourceMap": true
   },
-  "files": [
+  "exclude": [
     "typings/main.d.ts",
-    "src/client.ts",
-    "gulpfile.ts",
-    "Gruntfile.ts"
-  ]
+    "typings/main",
+    "node_modules"
+  ],
+  "compileOnSave": false,
+  "buildOnSave": false,
+  "atom": { "rewriteTsconfig": false }
 }

--- a/typings.json
+++ b/typings.json
@@ -2,14 +2,11 @@
   "ambientDependencies": {
     "orchestrator": "github:DefinitelyTyped/DefinitelyTyped/orchestrator/orchestrator.d.ts#422b006d39dd37fc667ce5464967ee3ff6135092",
     "Q": "github:DefinitelyTyped/DefinitelyTyped/q/Q.d.ts#aae1368c8ee377f6e9c59c2d6faf1acb3ece7e05",
-    "through2": "github:DefinitelyTyped/DefinitelyTyped/through2/through2.d.ts#48f20e97bfaf70fc1a9537b38aed98e9749be0ae",
     "gulp": "github:DefinitelyTyped/DefinitelyTyped/gulp/gulp.d.ts#052725d74978d6b8d7c4ff537b5a3b21ee755a49",
     "es6-shim": "github:DefinitelyTyped/DefinitelyTyped/es6-shim/es6-shim.d.ts#6697d6f7dadbf5773cb40ecda35a76027e0783b2",
     "express": "github:DefinitelyTyped/DefinitelyTyped/express/express.d.ts#2e7a477ac2b6471055aa6e0e56b333e8f327d6b7",
     "mime": "github:DefinitelyTyped/DefinitelyTyped/mime/mime.d.ts#2e7a477ac2b6471055aa6e0e56b333e8f327d6b7",
     "node": "github:DefinitelyTyped/DefinitelyTyped/node/node.d.ts#2e7a477ac2b6471055aa6e0e56b333e8f327d6b7",
-    "serve-static": "github:DefinitelyTyped/DefinitelyTyped/serve-static/serve-static.d.ts#2e7a477ac2b6471055aa6e0e56b333e8f327d6b7",
-    "zone": "github:DefinitelyTyped/DefinitelyTyped/zone.js/zone.js.d.ts#c393f8974d44840a6c9cc6d5b5c0188a8f05143d",
-    "ng2": "github:gdi2290/typings-ng2/ng2.d.ts#32998ff5584c0eab0cd9dc7704abb1c5c450701c"
+    "serve-static": "github:DefinitelyTyped/DefinitelyTyped/serve-static/serve-static.d.ts#2e7a477ac2b6471055aa6e0e56b333e8f327d6b7"
   }
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,42 +1,50 @@
+var webpackMerge = require('webpack-merge');
 var webpack = require('webpack');
 var path = require('path');
 
-module.exports = {
-  context: __dirname,
+var commonConfig = {
+  resolve: {
+    extensions: ['', '.ts', '.js']
+  },
+  module: {
+    loaders: [
+      // TypeScript
+      { test: /\.ts$/, loader: 'ts-loader', exclude: [ /node_modules/ ] }
+    ]
+  },
+  plugins: [
+    new webpack.optimize.OccurenceOrderPlugin(true)
+  ]
+};
+
+
+var clientConfig = {
   target: 'web',
   entry: './src/client',
   output: {
-    path: __dirname + '/dist/client',
-    publicPath: __dirname,
-    filename: 'bundle.js'
-  },
+    path: path.join(__dirname, 'dist', 'client')
+  }
+};
 
-  resolve: {
-    root: __dirname + '/src',
-    extensions: ['', '.ts', '.json', '.js']
-  },
-
+// Default config
+var defaultConfig = {
   module: {
-    loaders: [
-      {
-        test: /\.ts$/,
-        loader: 'ts-loader',
-        exclude: [ /node_modules/ ]
-      }
-    ],
     noParse: [
-      path.resolve('node_modules', 'es6-shim', 'dist'),
-      path.resolve('node_modules', 'angular2', 'bundles'),
-      path.resolve('node_modules', 'zone.js', 'dist'),
+      path.join(__dirname, 'zone.js', 'dist'),
+      path.join(__dirname, 'angular2', 'bundles')
     ]
   },
+  context: __dirname,
+  resolve: {
+    root: path.join(__dirname, '/src')
+  },
+  output: {
+    publicPath: path.resolve(__dirname),
+    filename: 'bundle.js'
+  }
+};
 
-  plugins: [
-    new webpack.optimize.OccurenceOrderPlugin(true),
-    new webpack.optimize.UglifyJsPlugin({
-      mangle: false,
-      comments: false
-    })
-  ]
-
-}
+module.exports = [
+  // Client
+  webpackMerge({}, defaultConfig, commonConfig, clientConfig)
+];


### PR DESCRIPTION
Package versions updated.

Most of the app runs but server-only-app doesn't seem to work.
Also, prerender is showing an error on 'npm start' with the latest versions of gulp and grunt prerender packages. This was not occurring on the older versions.

TypeScript 1.8 is causing an error due to duplicate engineOptions interface so typescript is left at version 1.7.5 for now.