### PR TITLE
Update body-parser typings

### DIFF
--- a/typings.json
+++ b/typings.json
@@ -1,6 +1,6 @@
 {
   "ambientDependencies": {
-    "body-parser": "github:DefinitelyTyped/DefinitelyTyped/body-parser/body-parser.d.ts#7de6c3dd94feaeb21f20054b9f30d5dabc5efabd",
+    "body-parser": "registry:dt/body-parser#0.0.0+20160317120654",
     "es6-shim": "github:DefinitelyTyped/DefinitelyTyped/es6-shim/es6-shim.d.ts#6697d6f7dadbf5773cb40ecda35a76027e0783b2",
     "express": "github:DefinitelyTyped/DefinitelyTyped/express/express.d.ts#2e7a477ac2b6471055aa6e0e56b333e8f327d6b7",
     "mime": "github:DefinitelyTyped/DefinitelyTyped/mime/mime.d.ts#2e7a477ac2b6471055aa6e0e56b333e8f327d6b7",


### PR DESCRIPTION
Body-parser added to registry now, previous github link was no longer working causing "Cannot find module: body-parser"

Linked to issue https://github.com/angular/universal/issues/349.

Should this be updated in the Universal project as well? Couldn't find where.