### PR TITLE
chore(build): improve deployment to Heroku

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: node dist/server/index.js

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ A minimal Angular 2 starter for Universal JavaScript using TypeScript and Webpac
 > If you're looking for the repo from the AngularConnect talk look in the [angular-connect branch](https://github.com/angular/universal-starter/tree/angular-connect)  
 If you're looking for a SystemJS version of the repo look in the [systemjs branch](https://github.com/angular/universal-starter/tree/systemjs)
 
+[![Deploy](https://www.herokucdn.com/deploy/button.svg)](https://heroku.com/deploy)
+
 ## Installation
 
 * `npm install`
@@ -19,4 +21,3 @@ If you're looking for a SystemJS version of the repo look in the [systemjs branc
 
 ## Watch files
 * `npm run watch` to build your client app and start a web server
-

--- a/app.json
+++ b/app.json
@@ -1,0 +1,12 @@
+{
+  "name": "Angular 2 Universal Starter",
+  "description": "Angular 2 Universal starter kit by @AngularClass",
+  "repository": "https://github.com/angular/universal-starter",
+  "logo": "https://cloud.githubusercontent.com/assets/1016365/10639063/138338bc-7806-11e5-8057-d34c75f3cafc.png",
+  "env": {
+    "NPM_CONFIG_PRODUCTION": {
+      "description": "Install `webpack` and other development modules when deploying to allow full builds.",
+      "value": "false"
+    }
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -58,6 +58,6 @@ app.get('*', function(req, res) {
 });
 
 // Server
-app.listen(3000, () => {
-  console.log('Listening on: http://localhost:3000');
+let server = app.listen(process.env.PORT || 3000, () => {
+  console.log(`Listening on: http://localhost:${server.address().port}`);
 });


### PR DESCRIPTION
Not sure if this is useful, but as I noted a `Procfile` in the repository I figured it's not completely out of scope. This makes some modifications to allow for one-click deployment to Heroku including a deploy button. Based on the conversations in #122

This process is good for a starter application and quick trial/error tests from a developer that is new to Universal. As that is the focus of this repository, it seems appropriate. It's not necessarily a configuration recommended for production if hosting on Heroku. However, it's probably a bit out of scope of this demo to go deeper into recommended build processes and deployment configuration.