### PR TITLE
remove source-map-loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "nodemon": "^1.10.0",
     "raw-loader": "^0.5.1",
     "rimraf": "^2.5.4",
-    "source-map-loader": "^0.1.5",
     "ts-loader": "^0.8.2",
     "typescript": "^2.0.0-beta",
     "webpack": "^2.1.0-beta.20",


### PR DESCRIPTION
```
preLoaders: [
  { test: /\.js$/, loader: 'source-map-loader' }
],
```
has been removed from webpack.config.js because of this [PR](https://github.com/angular/universal-starter/commit/a40f0d1b24d04a62a72bd1199ad0334405a76534).

**source-map-loader** is not necessary now.