### PR TITLE
Should use env.PORT like in server.

### DIFF
--- a/src/main.node.ts
+++ b/src/main.node.ts
@@ -27,7 +27,7 @@ export function ngApp(req, res) {
       App
     ],
     platformProviders: [
-      {provide: ORIGIN_URL, useValue: 'http://localhost:3000'},
+      {provide: ORIGIN_URL, useValue: 'http://localhost:' + (process.env.PORT || 3000)},
       {provide: APP_BASE_HREF, useValue: baseUrl},
     ],
     providers: [


### PR DESCRIPTION
Server will read port from env, but so should the access control.