### PR TITLE
bug(zone): Bump version to 23 to capture async events

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "express": "^4.14.0",
     "methods": "~1.1.2",
     "rxjs": "5.0.0-beta.12",
-    "zone.js": "0.6.21"
+    "zone.js": "0.6.23"
   },
   "devDependencies": {
     "@angularclass/resolve-angular-routes": "^1.0.9",


### PR DESCRIPTION
0.6.21 wasn't correctly capturing Zone async changes and updating the UI for it.
23 Fixes these.