### PR TITLE
added comma to weback.config to prevent ts syntax error 

### DIFF
--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -20,7 +20,7 @@ var commonConfig = {
       /angular(\\|\/)core(\\|\/)src(\\|\/)linker/,
       root('./src'),
       {}
-    )
+    ),
 
     // To use gzip, you can run 'npm install compression-webpack-plugin --save-dev'
     // add 'var CompressionPlugin = require("compression-webpack-plugin");' on the top


### PR DESCRIPTION
Added comma to weback.config.ts to prevent ts syntax error that comes after removing comments while enabling gzip compression. 
I faced the same error so thought will be good to add the comma to webpack config plugins array.
<img width="1186" alt="screen shot 2016-10-23 at 9 58 14 pm" src="https://cloud.githubusercontent.com/assets/3892451/19627735/e3e29796-996b-11e6-8929-6b55315e583e.png">

