### PR TITLE
Move template as well as styling into separate files

### DIFF
--- a/src/app/home/home.component.css
+++ b/src/app/home/home.component.css
@@ -1,0 +1,3 @@
+h1{
+  color: blue;
+}

--- a/src/app/home/home.component.html
+++ b/src/app/home/home.component.html
@@ -1,0 +1,1 @@
+<h1>Home component</h1>

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -1,8 +1,9 @@
-import { Component } from '@angular/core';
+import {Component} from '@angular/core';
 
 @Component({
   selector: 'home',
-  template: 'Home component'
+  templateUrl: './home.component.html',
+  styleUrls: ['./home.component.css']
 })
 export class HomeComponent {
 


### PR DESCRIPTION
Usually templates are loaded from templateUrl instead of template. This PR adds a home.component.html to the home component to demonstrate this usage.

In addition it introduces a css sheet to demonstrate this as well. 
