### PR TITLE
Add forRoot to shared module

### DIFF
--- a/src/app/app.browser.module.ts
+++ b/src/app/app.browser.module.ts
@@ -29,7 +29,7 @@ export const UNIVERSAL_KEY = 'UNIVERSAL_CACHE';
     UniversalModule, // BrowserModule, HttpModule, and JsonpModule are included
     FormsModule,
 
-    SharedModule,
+    SharedModule.forRoot(),
     HomeModule,
     AboutModule,
 

--- a/src/app/app.node.module.ts
+++ b/src/app/app.node.module.ts
@@ -30,7 +30,7 @@ export function getResponse() {
     UniversalModule, // NodeModule, NodeHttpModule, and NodeJsonpModule are included
     FormsModule,
 
-    SharedModule,
+    SharedModule.forRoot(),
     HomeModule,
     AboutModule,
 

--- a/src/app/shared/shared.module.ts
+++ b/src/app/shared/shared.module.ts
@@ -1,8 +1,7 @@
-import { NgModule } from '@angular/core';
-import { CommonModule }   from '@angular/common';
+import { NgModule, ModuleWithProviders } from '@angular/core';
+import { CommonModule } from '@angular/common';
 import { RouterModule } from '@angular/router';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-
 import { ApiService } from './api.service';
 import { ModelService } from './model/model.service';
 
@@ -35,13 +34,19 @@ const PROVIDERS = [
     ...PIPES,
     ...COMPONENTS
   ],
-  providers: [
-    ...PROVIDERS
-  ],
   exports: [
     ...MODULES,
     ...PIPES,
     ...COMPONENTS
   ]
 })
-export class SharedModule { }
+export class SharedModule {
+  static forRoot(): ModuleWithProviders {
+    return {
+      ngModule: SharedModule,
+      providers: [
+        ...PROVIDERS
+      ]
+    };
+  }
+}


### PR DESCRIPTION
using forRoot prevents that more than one instance of the service will be created.