### PR TITLE
set charset before any content

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -1,8 +1,8 @@
 <!doctype html>
 <html>
 <head>
-  <title>Angular 2 Universal Starter</title>
   <meta charset="UTF-8">
+  <title>Angular 2 Universal Starter</title>
   <meta name="description" content="Angular 2 Universal">
   <meta name="keywords" content="Angular 2,Universal">
   <meta name="author" content="PatrickJS">


### PR DESCRIPTION
It is strongly advised to declare document charset before content, especially title.