### PR TITLE
fix(webpack.prod): ensure only 'NODE_ENV' and 'AOT' is defined in 'process.env'

### DIFF
--- a/webpack.prod.config.ts
+++ b/webpack.prod.config.ts
@@ -12,10 +12,10 @@ export const commonPlugins = [
   new V8LazyParseWebpackPlugin(),
 
   new webpack.DefinePlugin({
-    'process.env': {
-      'NODE_ENV': JSON.stringify('production'),
-      'AOT': true
-    }
+    // do not use an object for 'process.env' otherwise all other environment
+    // variables are set to 'undefined' see issue #291
+    'process.env.NODE_ENV': JSON.stringify('production'),
+    'process.env.AOT': true
   }),
 
   // Loader options


### PR DESCRIPTION
Set value by value because an object overrides all other env variables.

This fixes bug #291