### PR TITLE
Bug: fix encoding bug when using brotli compression

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,8 +98,11 @@ app.use(interceptor((req, res)=>({
       }
     } else {
       const { output, encoding } = mcache.get(key);
-      res.setHeader('Content-Encoding', encoding);
-      send(output);
+      if(encodings.has(encoding)){
+          res.setHeader('Content-Encoding', encoding);
+          send(output);
+          return;
+      }
     }
     send(output);
   }


### PR DESCRIPTION
There's a bug for current documentation when you use brotli as default compression.

Step to reproduce this issue. 
1. Visit http://localhost:8000/data.json on browser
2. Visit http://localhost:8000/home

Server will crash because of the following reasons,

The first time you visit data.json. Since browser accept br compression, it will compress data.json and save it to cache.

The second time you visit home, there is a server side rending but angular universal don't anticipate any encoding compression then a crash will happen.

Javascript is asynchronous function, so send function will be execute twice even callback function was execute before. We need `return` after send function.