### PR TITLE
fix(deps): latest webpack enhanched resolver breaks the AOT build

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "rimraf": "^2.6.1",
     "script-ext-html-webpack-plugin": "^1.7.1",
     "typescript": "^2.3.2",
-    "webpack": "^3.3.0",
+    "webpack": "3.3.0",
     "webpack-merge": "^4.1.0"
   }
 }


### PR DESCRIPTION
Just use webpack 3.3.0 until issue is resolved.