### PR TITLE
Add nonce attribute for CSP

### DIFF
--- a/custom-webpack/src/modules/transfer-state/server-transfer-state.ts
+++ b/custom-webpack/src/modules/transfer-state/server-transfer-state.ts
@@ -29,6 +29,7 @@ export class ServerTransferState extends TransferState {
       }
 
       const script = renderer.createElement('script');
+      renderer.setAttribute(script, 'nonce', 'nonce-universal-transfer-state');
       renderer.setValue(script, `window['TRANSFER_STATE'] = ${transferStateString}`);
       renderer.appendChild(head, script);
     } catch (e) {


### PR DESCRIPTION
As discussed in https://github.com/angular/universal/issues/793, once rendered, transfer-state generate in the html output a script window['TRANSFER_STATE'] which add difficulty to set a Content-Security-Policy. Adding an attribute `nonce` allow to bypass transfer-state in this CSP.