### PR TITLE
fix(cli/package.json): add reflect-metadata

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -48,6 +48,7 @@
     "@angular/language-service": "^4.2.4",
     "cpy-cli": "^1.0.1",
     "http-server": "^0.10.0",
-    "typescript": "~2.3.3"
+    "typescript": "~2.3.3",
+    "reflect-metadata":"^0.1.10"
   }
 }


### PR DESCRIPTION
The [`reflect-metadata`](https://www.npmjs.com/package/reflect-metadata) module is used in both [server.js](https://github.com/angular/universal-starter/blob/master/cli/server.js#L2) and [predender.js](https://github.com/angular/universal-starter/blob/master/cli/prerender.js#L3), but it was forgotten in `package.json`.
