### PR TITLE
feat(cli): use ts-node for static and dynamic node scripts

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -1,22 +1,30 @@
 # Minimal Starter with the CLI
 
-## Installation
-
-* `npm install` or `yarn`
-
 ## Static or Dynamic
 
 This repo demonstrates the use of 2 different forms of Server Side Rendering.
 
-**Static** Also known as prerendering - This happens at build time; it renders your application and replaces the dist index.html with a rendered version.
+**Static** Also known as prerendering
+* Happens at build time
+* Renders your application and replaces the dist index.html with a version rendered at the route `/`.
 
-**Dynamic** - This happens at runtime; you use Server Side Engine such as the `ngExpressEngine` to render your application as requests come in.
+**Dynamic**
+* Happens at runtime
+* Uses `ngExpressEngine` to render you application on the fly at the requested url.
+
+
+## Installation
+* `npm install` or `yarn`
 
 ## Development
-* run `npm run start` which will start `ng serve`
+* run `npm run start`
 
 ## Prod
-* `npm run build:static` or `npm run build:dynamic` to compile your application for distribution
+* `npm run build:static` or `npm run build:dynamic`
+
+## Local Demo
+* `npm run serve:static` or `npm run serve:dynamic`
+ 
 
 This demo is built following this guide: https://github.com/angular/angular-cli/wiki/stories-universal-rendering
 Along with https://github.com/angular/universal/tree/master/modules/ng-module-map-ngfactory-loader to enable Lazy Loading

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng-universal-demo",
-  "version": "0.0.0",
+  "version": "4.0.0",
   "license": "MIT",
   "repository": {
     "type": "git",
@@ -19,10 +19,10 @@
     "ng": "ng",
     "start": "ng serve",
     "build": "ng build",
-    "build:static": "ng build --prod && ng build --prod --app 1 --output-hashing=false && node prerender",
-    "build:dynamic": "ng build --prod && ng build --prod --app 1 --output-hashing=false && cpy ./server.js ./dist",
+    "build:static": "ng build --prod && ng build --prod --app 1 --output-hashing=false && ts-node src/prerender",
+    "build:dynamic": "ng build --prod && ng build --prod --app 1 --output-hashing=false && cpy ./src/server.ts ./dist && cpy package.json ./dist",
     "serve:static": "npm run build:static && cd dist && http-server",
-    "serve:dynamic": "npm run build:dynamic && cd dist && node server"
+    "serve:dynamic": "npm run build:dynamic && cd dist && ts-node server"
   },
   "private": true,
   "dependencies": {
@@ -46,8 +46,10 @@
     "@angular/cli": "^1.3.0",
     "@angular/compiler-cli": "^4.2.4",
     "@angular/language-service": "^4.2.4",
+    "@types/express": "^4.0.37",
     "cpy-cli": "^1.0.1",
     "http-server": "^0.10.0",
+    "ts-node": "^3.3.0",
     "typescript": "~2.3.3"
   }
 }

--- a/cli/src/prerender.ts
+++ b/cli/src/prerender.ts
@@ -1,17 +1,16 @@
-// Load zone.js for the server.
-require('zone.js/dist/zone-node');
-require('reflect-metadata')
-const fs = require('fs');
+import 'zone.js/dist/zone-node';
+import 'reflect-metadata';
+import * as fs from 'fs';
 
 // Import renderModuleFactory from @angular/platform-server.
-const { renderModuleFactory } = require('@angular/platform-server');
+import { renderModuleFactory } from '@angular/platform-server';
 
 // Import module map for lazy loading
-const { provideModuleMap } = require('@nguniversal/module-map-ngfactory-loader');
+import { provideModuleMap }  from '@nguniversal/module-map-ngfactory-loader';
 
 // Import the AOT compiled factory for your AppServerModule.
 // This import will change with the hash of your built server bundle.
-const { AppServerModuleNgFactory, LAZY_MODULE_MAP } = require(`./dist/dist-server/main.bundle`);
+const { AppServerModuleNgFactory, LAZY_MODULE_MAP } = require(`../dist/dist-server/main.bundle`);
 
 // Load the index.html file containing referances to your application bundle.
 const index = fs.readFileSync('./dist/index.html', 'utf8');

--- a/cli/src/server.ts
+++ b/cli/src/server.ts
@@ -1,19 +1,19 @@
-require('zone.js/dist/zone-node');
-require('reflect-metadata');
-const express = require('express');
-const fs = require('fs');
+import 'zone.js/dist/zone-node';
+import 'reflect-metadata';
+import * as express from 'express';
+import * as fs from 'fs';
 
-const { platformServer, renderModuleFactory } = require('@angular/platform-server');
-const { ngExpressEngine } = require('@nguniversal/express-engine');
+import { platformServer, renderModuleFactory } from '@angular/platform-server';
+import { ngExpressEngine } from '@nguniversal/express-engine';
 // Import module map for lazy loading
-const { provideModuleMap } = require('@nguniversal/module-map-ngfactory-loader');
+import { provideModuleMap } from '@nguniversal/module-map-ngfactory-loader';
 
 // Import the AOT compiled factory for your AppServerModule.
 // This import will change with the hash of your built server bundle.
 const { AppServerModuleNgFactory, LAZY_MODULE_MAP } = require(`./dist-server/main.bundle`);
 
 const app = express();
-const port = 8000;
+const port = 8080;
 const baseUrl = `http://localhost:${port}`;
 
 // Set the engine

--- a/cli/yarn.lock
+++ b/cli/yarn.lock
@@ -2728,6 +2728,10 @@ magic-string@^0.22.3:
   dependencies:
     vlq "^0.2.1"
 
+make-error@^1.1.1:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.0.tgz#52ad3a339ccf10ce62b4040b708fe707244b8b96"
+
 map-obj@^1.0.0, map-obj@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-1.0.1.tgz#d933ceb9205d82bdcf4886f6742bdc2b4dea146d"
@@ -4222,6 +4226,12 @@ source-map-loader@^0.2.0:
     loader-utils "~0.2.2"
     source-map "~0.1.33"
 
+source-map-support@^0.4.0:
+  version "0.4.18"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
+  dependencies:
+    source-map "^0.5.6"
+
 source-map-support@^0.4.1, source-map-support@^0.4.2:
   version "0.4.16"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.16.tgz#16fecf98212467d017d586a2af68d628b9421cd8"
@@ -4391,7 +4401,7 @@ strip-indent@^1.0.1:
   dependencies:
     get-stdin "^4.0.1"
 
-strip-json-comments@~2.0.1:
+strip-json-comments@^2.0.0, strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
@@ -4533,6 +4543,28 @@ trim-newlines@^1.0.0:
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
+
+ts-node@^3.3.0:
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-3.3.0.tgz#c13c6a3024e30be1180dd53038fc209289d4bf69"
+  dependencies:
+    arrify "^1.0.0"
+    chalk "^2.0.0"
+    diff "^3.1.0"
+    make-error "^1.1.1"
+    minimist "^1.2.0"
+    mkdirp "^0.5.1"
+    source-map-support "^0.4.0"
+    tsconfig "^6.0.0"
+    v8flags "^3.0.0"
+    yn "^2.0.0"
+
+tsconfig@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/tsconfig/-/tsconfig-6.0.0.tgz#6b0e8376003d7af1864f8df8f89dd0059ffcd032"
+  dependencies:
+    strip-bom "^3.0.0"
+    strip-json-comments "^2.0.0"
 
 tsickle@^0.21.0:
   version "0.21.6"
@@ -4684,6 +4716,10 @@ url@^0.11.0:
     punycode "1.3.2"
     querystring "0.2.0"
 
+user-home@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/user-home/-/user-home-1.1.1.tgz#2b5be23a32b63a7c9deb8d0f28d485724a3df190"
+
 util-deprecate@~1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/util-deprecate/-/util-deprecate-1.0.2.tgz#450d4dc9fa70de732762fbd2d4a28981419a0ccf"
@@ -4713,6 +4749,12 @@ uuid@^2.0.2:
 uuid@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.1.0.tgz#3dd3d3e790abc24d7b0d3a034ffababe28ebbc04"
+
+v8flags@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/v8flags/-/v8flags-3.0.0.tgz#4be9604488e0c4123645def705b1848d16b8e01f"
+  dependencies:
+    user-home "^1.1.1"
 
 validate-npm-package-license@^3.0.1:
   version "3.0.1"
@@ -5009,6 +5051,10 @@ yargs@~3.10.0:
     cliui "^2.1.0"
     decamelize "^1.0.0"
     window-size "0.1.0"
+
+yn@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-2.0.0.tgz#e5adabc8acf408f6385fc76495684c88e6af689a"
 
 zone.js@^0.8.14:
   version "0.8.17"


### PR DESCRIPTION
There has been some confusion that you can use `server.js` in the root of the project without doing any of the build steps. To avoid this I've moved the `server.js` and `prerender.js` into `/src` and renamed to `.ts` then changed the build commands to use `ts-node` to avoid any confusion that might arise aswell as to remain consistent  with using TS
