### PR TITLE
refactor(cli): move ts files into src and clean up prerender

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -39,7 +39,7 @@
     "@angular/http": "^4.2.4",
     "@angular/platform-browser": "^4.2.4",
     "@angular/platform-browser-dynamic": "^4.2.4",
-    "@angular/platform-server": "^4.3.6",
+    "@angular/platform-server": "^4.2.4",
     "@angular/router": "^4.2.4",
     "@nguniversal/express-engine": "^1.0.0-beta.3",
     "@nguniversal/module-map-ngfactory-loader": "^1.0.0-beta.3",

--- a/cli/prerender.ts
+++ b/cli/prerender.ts
@@ -3,7 +3,6 @@ import 'zone.js/dist/zone-node';
 import 'reflect-metadata';
 import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'fs';
 import { join } from 'path';
-import { chdir } from 'process';
 
 import { enableProdMode } from '@angular/core';
 // Faster server renders w/ Prod mode (dev mode never needed)
@@ -13,42 +12,34 @@ enableProdMode();
 import { ngExpressEngine } from '@nguniversal/express-engine';
 // Import module map for lazy loading
 import { provideModuleMap } from '@nguniversal/module-map-ngfactory-loader';
-
 import { renderModuleFactory } from '@angular/platform-server';
+import { ROUTES } from './static.paths';
 
 // * NOTE :: leave this as require() since this file is built Dynamically from webpack
 const { AppServerModuleNgFactory, LAZY_MODULE_MAP } = require('./dist/server/main.bundle');
-
-// Get route paths to prerender only static pages
-const PATHS = require('./static.paths');
 
 const BROWSER_FOLDER = join(process.cwd(), 'browser');
 
 // Load the index.html file containing referances to your application bundle.
 const index = readFileSync(join('browser', 'index.html'), 'utf8');
 
-let prom = Promise.resolve();
+let previousRender = Promise.resolve();
 
 // Iterate each route path
-PATHS.forEach(function (route) {
-  // Changes current directory to ./dist/browser
-  chdir(BROWSER_FOLDER);
+ROUTES.forEach(route => {
+  var fullPath = join(BROWSER_FOLDER, route);
 
-  // Creates new directories (if not exists) and changes current directory for the nested one
-  route.split('/').filter(val => val !== '')
-    .forEach(function (dir) {
-      if (!existsSync(dir)) {
-        mkdirSync(dir);
-      }
-      chdir(dir);
-    });
+  // Make sure the directory structure is there
+  if(!existsSync(fullPath)){
+    mkdirSync(fullPath);
+  }
 
   // Writes rendered HTML to index.html, replacing the file if it already exists.
-  prom = prom.then(_ => renderModuleFactory(AppServerModuleNgFactory, {
+  previousRender = previousRender.then(_ => renderModuleFactory(AppServerModuleNgFactory, {
     document: index,
     url: route,
     extraProviders: [
       provideModuleMap(LAZY_MODULE_MAP)
     ]
-  })).then(html => writeFileSync(join(BROWSER_FOLDER, route, 'index.html'), html));
+  })).then(html => writeFileSync(join(fullPath, 'index.html'), html));
 });

--- a/cli/src/tsconfig.app.json
+++ b/cli/src/tsconfig.app.json
@@ -4,7 +4,9 @@
     "outDir": "../out-tsc/app",
     "baseUrl": "./",
     "module": "es2015",
-    "types": []
+    "types": [
+      "node"
+    ]
   },
   "exclude": [
     "test.ts",

--- a/cli/src/tsconfig.server.json
+++ b/cli/src/tsconfig.server.json
@@ -5,7 +5,9 @@
     "baseUrl": "./",
     // Set the module format to "commonjs":
     "module": "commonjs",
-    "types": []
+    "types": [
+      "node"
+    ]
   },
   "exclude": [
     "test.ts",

--- a/cli/static.paths.ts
+++ b/cli/static.paths.ts
@@ -1,4 +1,4 @@
-module.exports = [
+export const ROUTES = [
   '/',
   '/lazy',
   '/lazy/nested'


### PR DESCRIPTION
* removed unnecessary logic in prerender.ts
* moved server.ts, prerender.ts and static.paths.ts into src since they are src files
* replaced static.paths.js with static.path.ts to be consistant
* changed platform-server version to match other versions