### PR TITLE
Fix lint and not existing tsconfig files

### DIFF
--- a/.angular-cli.json
+++ b/.angular-cli.json
@@ -62,14 +62,6 @@
       {
         "project": "src/tsconfig.app.json",
         "exclude": "**/node_modules/**"
-      },
-      {
-        "project": "src/tsconfig.spec.json",
-        "exclude": "**/node_modules/**"
-      },
-      {
-        "project": "e2e/tsconfig.e2e.json",
-        "exclude": "**/node_modules/**"
       }
     ],
     "test": {


### PR DESCRIPTION
lint config in .angular-cli.json is referencing tsconfig files which doesn't exist in the project

After having sync my app with the last changes of the repo, I wasn't able to commit anymore because lint was throwing error like

    Commit failed with error
       typeof-compare is deprecated. Starting from TypeScript 2.2 the compiler includes this check which makes this rule redundant.
       error TS5058: The specified path does not exist: 'e2e/tsconfig.e2e.json'.
       FatalError: error TS5058: The specified path does not exist: 'e2e/tsconfig.e2e.json'.

or

       error TS5058: The specified path does not exist: 'src/tsconfig.spec.json'.
       FatalError: error TS5058: The specified path does not exist: 'src/tsconfig.spec.json'.

Removing these two not existing references in .angular-cli.json solve the issue for me

