### PR TITLE
chore(webpack): remove redundant `main` external regex

### DIFF
--- a/webpack.server.config.js
+++ b/webpack.server.config.js
@@ -13,7 +13,7 @@ module.exports = {
   target: 'node',
   resolve: { extensions: ['.ts', '.js'] },
   // Make sure we include all node_modules etc
-  externals: [/(node_modules|main\..*\.js)/,],
+  externals: [/node_modules/],
   output: {
     // Puts the output at the root of the dist folder
     path: path.join(__dirname, 'dist'),


### PR DESCRIPTION
The `main` part of the regex is redundant as because of the `.js` extension it is not matching the `require` statement in `server.ts`. If it was matching, so the `require` statement in `server.ts` had the `.js` ending , the generated bundle would fail as the output would look like this:
```js
/***/ }),
/* 257 */
/***/ (function(module, exports) {

module.exports = ./dist/server/main.bundle.js;

/***/ })
/******/ ]);
```