### PR TITLE
disabled webpack System.import warning

### DIFF
--- a/webpack.server.config.js
+++ b/webpack.server.config.js
@@ -22,7 +22,13 @@ module.exports = {
   },
   module: {
     rules: [
-      { test: /\.ts$/, loader: 'ts-loader' }
+      { test: /\.ts$/, loader: 'ts-loader' },
+      {
+        // Mark files inside `@angular/core` as using SystemJS style dynamic imports.
+        // Removing this will cause deprecation warnings to appear.
+        test: /[\/\\]@angular[\/\\]core[\/\\].+\.js$/,
+        parser: { system: true },
+      },
     ]
   },
   plugins: [


### PR DESCRIPTION
This config disables the warning from webpack:
>System.import() is deprecated and will be removed soon. Use import() instead.

closes https://github.com/angular/universal-starter/issues/579