### PR TITLE
lint(prerender.ts):  Forbidden 'var' keyword, use 'const' instead

### DIFF
--- a/prerender.ts
+++ b/prerender.ts
@@ -25,10 +25,10 @@ let previousRender = Promise.resolve();
 
 // Iterate each route path
 ROUTES.forEach(route => {
-  var fullPath = join(BROWSER_FOLDER, route);
+  const fullPath = join(BROWSER_FOLDER, route);
 
   // Make sure the directory structure is there
-  if(!existsSync(fullPath)){
+  if (!existsSync(fullPath)) {
     mkdirSync(fullPath);
   }
 


### PR DESCRIPTION
Missing whitespaces

Tested with https://www.codefactor.io/