### PR TITLE
fix(webpack.server.config): Unnecessary escape character: \/

### DIFF
--- a/webpack.server.config.js
+++ b/webpack.server.config.js
@@ -26,7 +26,7 @@ module.exports = {
       {
         // Mark files inside `@angular/core` as using SystemJS style dynamic imports.
         // Removing this will cause deprecation warnings to appear.
-        test: /[\/\\]@angular[\/\\]core[\/\\].+\.js$/,
+        test: /(\\|\/)@angular(\\|\/)core(\\|\/).+\.js$/,
         parser: { system: true },
       },
     ]


### PR DESCRIPTION
Avoid warnings given by codefactor.io and other linters by refactoring
the regex using capturing groups like in the lines below.

Linked to #579