### PR TITLE
fix: remove exclude node_modules

### DIFF
--- a/webpack.server.config.js
+++ b/webpack.server.config.js
@@ -13,8 +13,6 @@ module.exports = {
   },
   target: 'node',
   resolve: { extensions: ['.ts', '.js'] },
-  // Make sure we don't include all node_modules
-  externals: [/node_modules/],
   optimization: {
     minimize: false
   },


### PR DESCRIPTION
Following a convo with Fabian Wiles @Toxicable 09:10
@alan-agius4 we're actually planning on removing the webpack config from that when I get some time next But it should include all of node_modules I'm not sure when that exclude got there


Also, this doesn't have any effect in `Webpack 4` as the externals need to match the package name and not the path