### PR TITLE
Improved webpack externas handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "ts-loader": "^4.2.0",
     "tslint": "^5.7.0",
     "typescript": "~2.7.2",
-    "webpack-cli": "^2.0.14"
+    "webpack-cli": "^2.0.14",
+    "webpack-node-externals": "^1.7.2"
   }
 }

--- a/webpack.server.config.js
+++ b/webpack.server.config.js
@@ -2,6 +2,7 @@
 
 const path = require('path');
 const webpack = require('webpack');
+const nodeExternals = require('webpack-node-externals');
 
 module.exports = {
   mode: 'none',
@@ -12,6 +13,7 @@ module.exports = {
     prerender: './prerender.ts'
   },
   target: 'node',
+  externals: [nodeExternals()],
   resolve: { extensions: ['.ts', '.js'] },
   optimization: {
     minimize: false

--- a/yarn.lock
+++ b/yarn.lock
@@ -7370,6 +7370,10 @@ webpack-merge@^4.1.2:
   dependencies:
     lodash "^4.17.5"
 
+webpack-node-externals@^1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/webpack-node-externals/-/webpack-node-externals-1.7.2.tgz#6e1ee79ac67c070402ba700ef033a9b8d52ac4e3"
+
 webpack-sources@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/webpack-sources/-/webpack-sources-1.0.1.tgz#c7356436a4d13123be2e2426a05d1dad9cbe65cf"


### PR DESCRIPTION
Utilised 'webpack-node-externals' to ignore node_module dependancies from the build. 

This fixes the moongoose error #620 