### PR TITLE
build: Move reflect-metadata & express from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,8 @@
     "@nguniversal/express-engine": "^6.0.0",
     "@nguniversal/module-map-ngfactory-loader": "^6.0.0",
     "core-js": "^2.4.1",
+    "express": "^4.15.2",
+    "reflect-metadata": "^0.1.10",
     "rxjs": "^6.2.2",
     "zone.js": "^0.8.26"
   },
@@ -55,10 +57,8 @@
     "@angular/language-service": "^6.0.0",
     "@types/node": "^8.0.30",
     "codelyzer": "^4.0.2",
-    "express": "^4.15.2",
     "http-server": "^0.10.0",
     "pre-commit": "^1.2.2",
-    "reflect-metadata": "^0.1.10",
     "ts-loader": "^4.2.0",
     "tslint": "^5.7.0",
     "typescript": "~2.7.2"


### PR DESCRIPTION
This fixes an issue I ran into while proving out a production-ready environment for hosting a Universal app. I noticed some *devDependencies* modules are required to be installed in order to run the application, which should not be the case.

Changes in a nutshell: Moves **express** and **reflect-metadata** from devDependencies to run dependencies.

### Steps to reproduce issue

1. Clone repo, run `npm install`
1. Build project with `npm run build:ssr`
1. Remove `node_modules`
1. Run `npm install --production` to install run-time modules
1. Run `node  dist/server`

Following these steps, the node server will crash on launch due to missing dependencies:

```internal/modules/cjs/loader.js:583
> node dist/server
    throw err;
    ^
Error: Cannot find module 'reflect-metadata'
    at Function.Module._resolveFilename (internal/modules/cjs/loader.js:581:15)
    at Function.Module._load (internal/modules/cjs/loader.js:507:25)
    at Module.require (internal/modules/cjs/loader.js:637:17)
    at require (internal/modules/cjs/helpers.js:20:18)
    at Object.<anonymous> (/home/dbartel/projects/ext/universal-starter/dist/server.js:4:1)
    at Module._compile (internal/modules/cjs/loader.js:689:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:700:10)
    at Module.load (internal/modules/cjs/loader.js:599:32)
    at tryModuleLoad (internal/modules/cjs/loader.js:538:12)
    at Function.Module._load (internal/modules/cjs/loader.js:530:3)
```
