### PR TITLE
fix: update angular cli schema path

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "./node_modules/@angular-devkit/core/src/workspace/workspace-schema.json",
+  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
   "version": 1,
   "newProjectRoot": "projects",
   "projects": {


### PR DESCRIPTION
`ng new` generates this as a schema path.

As the workspace schema doesn't validate all properties within the builders